### PR TITLE
Add data_protection_config to WAFv2 Web ACL

### DIFF
--- a/waf_acl.tf
+++ b/waf_acl.tf
@@ -88,6 +88,19 @@ resource "aws_wafv2_web_acl" "waf_acl" {
     allow {}
   }
 
+  data_protection_config {
+    data_protection {
+      action                     = "SUBSTITUTION"
+      exclude_rate_based_details = false
+      exclude_rule_match_details = false
+
+      field {
+        field_keys = ["authorization"]
+        field_type = "SINGLE_HEADER"
+      }
+    }
+  }
+
   rule {
     name = "CloudFrontGlobal-sql-xss"
     priority = 0


### PR DESCRIPTION
- Add data_protection configuration block to aws_wafv2_web_acl resource to match console configuration and remove Terraform drift.
- The configuration protects the authorization header using substitution.